### PR TITLE
chore: Updated to allowed GPG with passwords

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
       id: import_gpg
       uses: crazy-max/ghaction-import-gpg@v4
       with:
-        gpg_private_key: ${{ secrets.GPG_SECRET_KEY }}
-        passphrase: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
     - name: 'Sign Jars'
       run: |
         export GPG_TTY=$(tty)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         export GPG_TTY=$(tty)
         for jar in pgjdbc/build/libs/*.jar; do gpg --detach-sign --armor $jar; done
-        for signed in build/libs/*.asc; do gpg --verify $signed; done
+        for signed in pgjdbc/build/libs/*.asc; do gpg --verify $signed; done
     - name: 'Upload to Release'
       uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,16 @@ jobs:
         touch RELEASE_DETAILS.md
         echo "$RELEASE_DETAILS" > RELEASE_DETAILS.md
     - name: 'Install GPG Secret Key'
-      id: install-secret-key
-      run: |
-        cat <(echo -e "${{ secrets.GPG_SECRET_KEY }}") | gpg --batch --import
+      id: import_gpg
+      uses: crazy-max/ghaction-import-gpg@v4
+      with:
+        gpg_private_key: ${{ secrets.GPG_SECRET_KEY }}
+        passphrase: ${{ secrets.GPG_SECRET_KEY_PASSWORD }}
     - name: 'Sign Jars'
       run: |
         export GPG_TTY=$(tty)
         for jar in pgjdbc/build/libs/*.jar; do gpg --detach-sign --armor $jar; done
+        for signed in build/libs/*.asc; do gpg --verify $signed; done
     - name: 'Upload to Release'
       uses: ncipollo/release-action@v1
       with:


### PR DESCRIPTION
### Summary

Release Process Automation

### Description

Updated workflow for `release` to be able to use GPG keys with passphrase.
GPG Private key stored in GitHub Actions, `GPG_SECRET_KEY`
Private Key Passphrase stored in GitHub Actions, `GPG_SECRET_KEY_PASSWORD`

### Additional Reviewers

@karenc-bq 
